### PR TITLE
Fix logout route placement

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,6 @@ Route::get('/recent-additions', [HomeController::class, 'recentAdditions'])->nam
 Route::middleware('guest')->group(function () {
     Route::get('login', 'App\Http\Controllers\Auth\LoginController@showLoginForm')->name('login');
     Route::post('login', 'App\Http\Controllers\Auth\LoginController@login');
-    Route::post('logout', 'App\Http\Controllers\Auth\LoginController@logout')->name('logout');
     
     // Registration Routes...
     Route::get('register', 'App\Http\Controllers\Auth\RegisterController@showRegistrationForm')->name('register');
@@ -32,6 +31,7 @@ Route::middleware('guest')->group(function () {
 
 // Authenticated Routes
 Route::middleware('auth')->group(function () {
+    Route::post('logout', 'App\\Http\\Controllers\\Auth\\LoginController@logout')->name('logout');
     // User Management
     Route::get('users', 'App\Http\Controllers\UserController@index')->name('users.index');
     Route::get('users/{user}', 'App\Http\Controllers\UserController@show')->name('users.show');


### PR DESCRIPTION
## Summary
- move the logout route into the `auth` middleware group so logged-in users can log out

## Testing
- `composer install --no-interaction --no-progress`
- `npm install --silent`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6884c7b4ce248331a131f546db494485